### PR TITLE
Fix API functions and hooks metadata

### DIFF
--- a/ferum_customs/api.py
+++ b/ferum_customs/api.py
@@ -1,15 +1,50 @@
+import frappe
 from frappe import _, whitelist
 from frappe.exceptions import PermissionError
 from typing import Optional
 
+
 @whitelist()
 def validate_service_request(docname: str) -> Optional[dict]:
-    """Validate service request""""
-    if not frappe.has_permission( "Service Request", "update"):
+    """Return the service request document as a dict after permission check."""
+    if not frappe.has_permission("Service Request", "read"):
         frappe.throw(_("Not permitted"), PermissionError)
+
     try:
         doc = frappe.get_doc("Service Request", docname)
         return doc.as_dict()
-    except Exception as e:
+    except Exception:
         frappe.log_error(frappe.get_traceback(), "Error validating Service Request")
         raise
+
+
+@whitelist()
+def on_submit_service_request(docname: str) -> None:
+    """Hook executed when a Service Request is submitted."""
+    frappe.logger(__name__).info(f"Service Request '{docname}' submitted")
+
+
+@whitelist()
+def cancel_service_request(docname: str) -> None:
+    """Hook executed when a Service Request is cancelled."""
+    frappe.logger(__name__).info(f"Service Request '{docname}' cancelled")
+
+
+@whitelist()
+def validate_service_report(docname: str) -> Optional[dict]:
+    """Return the service report document as a dict after permission check."""
+    if not frappe.has_permission("Service Report", "read"):
+        frappe.throw(_("Not permitted"), PermissionError)
+
+    try:
+        doc = frappe.get_doc("Service Report", docname)
+        return doc.as_dict()
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "Error validating Service Report")
+        raise
+
+
+@whitelist()
+def on_submit_service_report(docname: str) -> None:
+    """Hook executed when a Service Report is submitted."""
+    frappe.logger(__name__).info(f"Service Report '{docname}' submitted")

--- a/ferum_customs/hooks.py
+++ b/ferum_customs/hooks.py
@@ -3,7 +3,7 @@ from frappe import _
 
 app_name = "ferum_customs"
 app_title = "Ferum Customs"
-app_ublisher = "Ferum LLC"
+app_publisher = "Ferum LLC"
 app_description = "Specific custom functionality for ERPNext"
 app_email = "support@ferum.ru"
 app_license = "MIT"


### PR DESCRIPTION
## Summary
- restore API handlers with proper logging and permission checks
- correct variable name in `hooks.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_6841454911548328be8e6bb2e418a78f