### PR TITLE
Clean package initialization comments

### DIFF
--- a/ferum_customs/__init__.py
+++ b/ferum_customs/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""Ferum Customs Frappe application."""

--- a/ferum_customs/custom_logic/__init__.py
+++ b/ferum_customs/custom_logic/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""Logic hooks and helpers for Ferum Customs."""

--- a/ferum_customs/doctype/__init__.py
+++ b/ferum_customs/doctype/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""DocType definitions for Ferum Customs."""

--- a/ferum_customs/doctype/assigned_engineer_item/__init__.py
+++ b/ferum_customs/doctype/assigned_engineer_item/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""DocType package."""

--- a/ferum_customs/doctype/custom_attachment/__init__.py
+++ b/ferum_customs/doctype/custom_attachment/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""DocType package."""

--- a/ferum_customs/doctype/payroll_entry_custom/__init__.py
+++ b/ferum_customs/doctype/payroll_entry_custom/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""DocType package."""

--- a/ferum_customs/doctype/project_object_item/__init__.py
+++ b/ferum_customs/doctype/project_object_item/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""DocType package."""

--- a/ferum_customs/doctype/service_object/__init__.py
+++ b/ferum_customs/doctype/service_object/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""DocType package."""

--- a/ferum_customs/doctype/service_project/__init__.py
+++ b/ferum_customs/doctype/service_project/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""DocType package."""

--- a/ferum_customs/doctype/service_report/__init__.py
+++ b/ferum_customs/doctype/service_report/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""DocType package."""

--- a/ferum_customs/doctype/service_report_document_item/__init__.py
+++ b/ferum_customs/doctype/service_report_document_item/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""DocType package."""

--- a/ferum_customs/doctype/service_report_work_item/__init__.py
+++ b/ferum_customs/doctype/service_report_work_item/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""DocType package."""

--- a/ferum_customs/notifications/__init__.py
+++ b/ferum_customs/notifications/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""Notification configuration for Ferum Customs."""

--- a/ferum_customs/patches/__init__.py
+++ b/ferum_customs/patches/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""Database patches for Ferum Customs."""

--- a/ferum_customs/patches/v1_0/__init__.py
+++ b/ferum_customs/patches/v1_0/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""Patch set v1.0 for Ferum Customs."""

--- a/ferum_customs/permissions/__init__.py
+++ b/ferum_customs/permissions/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""Permissions utilities for Ferum Customs."""

--- a/ferum_customs/tests/__init__.py
+++ b/ferum_customs/tests/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""Test suite for Ferum Customs."""

--- a/ferum_customs/utils/__init__.py
+++ b/ferum_customs/utils/__init__.py
@@ -1,2 +1,1 @@
-# ferum_customs/custom_logic/__init__.py
-# This file makes Python treat the directory custom_logic as a package.
+"""Utility functions for Ferum Customs."""


### PR DESCRIPTION
## Summary
- add short docstrings to package `__init__` files
- remove outdated copy/pasted comments

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 ferum_customs`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_684179ef5754832895281ee732774668