### PR TITLE
Fix message formatting

### DIFF
--- a/ferum_customs/custom_logic/service_request_hooks.py
+++ b/ferum_customs/custom_logic/service_request_hooks.py
@@ -184,8 +184,11 @@ def _notify_project_manager(doc: "ServiceRequest") -> None:
 
         link_to_request = frappe.utils.get_link_to_form("ServiceRequest", doc.name)
 
-        message = f"""<p>{message_body.replace("\n", "<br>")}</p>
-<p><a href='{link_to_request}'>{_('Просмотреть заявку на обслуживание')}</a></p>"""
+        message = "<p>{}</p><p><a href='{}'>{}</a></p>".format(
+            message_body.replace("\n", "<br>"),
+            link_to_request,
+            _("Просмотреть заявку на обслуживание"),
+        )
 
         frappe.sendmail(
             recipients=recipients,
@@ -204,4 +207,3 @@ def _notify_project_manager(doc: "ServiceRequest") -> None:
             f"Failed to send closure notification for ServiceRequest '{doc.name}': {e}",
             exc_info=True,
         )
-


### PR DESCRIPTION
## Summary
- format notification email correctly

## Testing
- `pre-commit run --files ferum_customs/api.py ferum_customs/hooks.py ferum_customs/doctype/service_request/service_request.py ferum_customs/custom_logic/service_request_hooks.py ferum_customs/custom_logic/file_attachment_utils.py ferum_customs/doctype/custom_attachment/custom_attachment.py`
- `pytest -q` *(fails: RuntimeError: object is not bound)*

------
https://chatgpt.com/codex/tasks/task_e_6841806c47d08328bfd2ad474f206dbf