### PR TITLE
Fix docker scripts and constants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
 FROM python:3.10-slim
 
-RUN apt-get update && apt-get install -y git mariadb-client redis-server nodejs npm curl cron && npm install -g yarnt=1.22.19
+RUN apt-get update \
+    && apt-get install -y git mariadb-client redis-server nodejs npm curl cron \
+    && npm install -g yarn@1.22.19 \
+    && useradd -ms /bin/bash frappe
 
 USER frappe
 WORKDIR /home/frappe
 
-RUN pip install --user frappe-bench && \
-    ~/.local/bin/bench init frappe-bench --frappe-branch version-15 --skip-assets
+RUN pip install --user frappe-bench \
+    && ~/.local/bin/bench init frappe-bench --frappe-branch version-15 --skip-assets
 
 COPY bootstrap.sh /bootstrap.sh
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /bootstrap.sh /entrypoint.sh
 
-ENTRYPOINT "/entrypoint.sh"
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,19 +1,11 @@
 #!/bin/bash
 set -e
 
-BENCH_FOLDER="${BUNCH_NAME}:-bench"
+BENCH_FOLDER="${BENCH_FOLDER:-frappe-bench}"
 
-# Initialization scripts
-bench init frappe-bench --frappe-branch version-14 --no-redis --no-backups --skip-assets
+if [ ! -d "$BENCH_FOLDER" ]; then
+    /bootstrap.sh
+fi
 
-cd frappe-bench
-
-bench new-site dev.localhost --admin-password admin --mariadb-root-password root
-
-bench get-app ferum_customs --source-path /workspace
-bench --site dev.localhost install-app ferum_customs
-
-echo "[Info Bundle] Will run tests..."
-pytest --app ferum_customs
-
+cd "$BENCH_FOLDER"
 exec "$@"

--- a/ferum_customs/constants.py
+++ b/ferum_customs/constants.py
@@ -26,7 +26,6 @@ STATUS_REJECTED: str = "Rejected"
 # и в других частях системы (например, service_report_hooks.py использует STATUS_VYPOLNENA)
 STATUS_OTKRYTA: str = "Открыта"  # Соответствует "Open" или начальному статусу
 STATUS_V_RABOTE: str = "В работе"  # Соответствует "In Progress" / "Working"
-STATUS_PRIOSTANOVLENA: str = "Приостановлена"  # Соответствует "On Hold"
 STATUS_VYPOLNENA: str = (
     "Выполнена"  # Соответствует "Completed" (работа завершена инженером)
 )
@@ -36,7 +35,6 @@ STATUS_ZAKRYTA: str = (
 STATUS_OTMENENA: str = (
     "Отменена"  # Соответствует "Cancelled" (отменена инициатором или системой)
 )
-STATUS_OTKLONENA: str = "Отклонена"  # Соответствует "Rejected" (отклонена исполнителем)
 
 
 # --- Роли Пользователей ---
@@ -53,7 +51,6 @@ ROLE_CUSTOMER: str = "Customer"  # Пример
 ROLE_PROEKTNYJ_MENEDZHER: str = "Проектный менеджер"  # Из fixtures/role.json
 ROLE_INZHENER: str = "Инженер"  # Из fixtures/role.json
 ROLE_ZAKAZCHIK: str = "Заказчик"  # Из fixtures/role.json
-ROLE_OFIS_MENEDZHER: str = "Офис-менеджер"  # Из fixtures/role.json
 
 
 # --- Типы вложений (CustomAttachment) ---
@@ -83,11 +80,9 @@ __all__ = [
     "STATUS_REJECTED",
     "STATUS_OTKRYTA",
     "STATUS_V_RABOTE",
-    "STATUS_PRIOSTANOVLENA",
     "STATUS_VYPOLNENA",
     "STATUS_ZAKRYTA",
     "STATUS_OTMENENA",
-    "STATUS_OTKLONENA",
     # Роли
     "ROLE_SYSTEM_MANAGER",
     "ROLE_ADMINISTRATOR",
@@ -97,7 +92,6 @@ __all__ = [
     "ROLE_PROEKTNYJ_MENEDZHER",
     "ROLE_INZHENER",
     "ROLE_ZAKAZCHIK",
-    "ROLE_OFIS_MENEDZHER",
     # Типы вложений
     "ATTACHMENT_TYPE_PHOTO",
     "ATTACHMENT_TYPE_DOCUMENT",


### PR DESCRIPTION
## Summary
- clean up Docker image build
- revise entrypoint bootstrap logic
- fix bootstrap script
- sync constants with fixtures

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_6841b699e82083289decb0c36ab28e7d