### PR TITLE
Fix environment setup and entrypoint scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ setup.sh                   # пример развертывания ERPNext 15
 
 ```bash
 pip install -r dev-requirements.txt
+bash bootstrap.sh  # инициализация Bench и создание тестового сайта
 pytest --app ferum_customs
 ruff check ferum_customs
 ```

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,2 @@
-frappe @ git+https://github.com/frappe/frappe.git@version-14
-erpnext @ git+https://github.com/frappe/erpnext.git@version-14
+frappe @ git+https://github.com/frappe/frappe.git@version-15
+erpnext @ git+https://github.com/frappe/erpnext.git@version-15

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   mariadb:
     image: mariadb:10.6
     environment:
-      MYSQL/ROOT_PASSWORD: root
+      MYSQL_ROOT_PASSWORD: root
     volumes:
       - mariadb:/var/lib/mysql
 
@@ -21,7 +21,7 @@ services:
       - redis
     environment:
       SITE_NAME: your-site-name
-      DF_ROOT_USER: root
+      DB_ROOT_USER: root
       MYSQL_ROOT_PASSWORD: root
       ADMIN_PASSWORD: admin
       INSTALL_APPS: erpnext,ferum_customs

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,4 +8,10 @@ if [ ! -d "$BENCH_FOLDER" ]; then
 fi
 
 cd "$BENCH_FOLDER"
-exec "$@"
+
+if [[ "$1" == "pytest" ]]; then
+    shift
+    bench --site "${SITE_NAME:-dev.localhost}" run-tests --app ferum_customs "$@"
+else
+    exec "$@"
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@ set -e
 echo "🔧 Starting setup for ERPNext 15..."
 
 sudo apt-get update
-sudo apt-get install -y git python3-dev python3-pip python3-virtual-env mariaddb-server redis-server nodejs npm yarn curl
+sudo apt-get install -y git python3-dev python3-pip python3-venv mariadb-server redis-server nodejs npm yarn curl
 
 pip3 install frappe-bench
 


### PR DESCRIPTION
## Summary
- fix README dev instructions
- update dev requirements for frappe v15
- correct docker-compose env vars
- update entrypoint script for tests
- fix typos in setup script

## Testing
- `pytest -q`
- `ruff check ferum_customs`


------
https://chatgpt.com/codex/tasks/task_e_6841bf3c47048328af1ffc48ea87add3