### PR TITLE
Add tests and CI for Frappe hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install flake8
+      - run: flake8 ferum_customs
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build -t ferum_customs .
+      - name: Run tests
+        run: docker run --rm ferum_customs pytest --cov=ferum_customs --cov-report=xml
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage.xml

--- a/ferum_customs/tests/test_service_report_hooks.py
+++ b/ferum_customs/tests/test_service_report_hooks.py
@@ -1,0 +1,35 @@
+import pytest
+
+pytest.importorskip("frappe")
+import frappe
+from types import SimpleNamespace
+from ferum_customs.custom_logic import service_report_hooks
+from ferum_customs.constants import STATUS_VYPOLNENA
+
+
+class DummyDoc(SimpleNamespace):
+    def get(self, key):
+        return getattr(self, key, None)
+
+
+def test_validate_ok(monkeypatch):
+    doc = DummyDoc(service_request="REQ-1", name="SR-1")
+    monkeypatch.setattr(frappe.db, "exists", lambda *a, **k: True)
+    monkeypatch.setattr(frappe.db, "get_value", lambda *a, **k: STATUS_VYPOLNENA)
+    service_report_hooks.validate(doc)
+
+
+def test_validate_missing_request(monkeypatch):
+    doc = DummyDoc(service_request=None, name="SR-1")
+    monkeypatch.setattr(frappe, "throw", lambda *a, **k: (_ for _ in ()).throw(Exception("throw")))
+    with pytest.raises(Exception):
+        service_report_hooks.validate(doc)
+
+
+def test_validate_wrong_status(monkeypatch):
+    doc = DummyDoc(service_request="REQ-1", name="SR-1")
+    monkeypatch.setattr(frappe.db, "exists", lambda *a, **k: True)
+    monkeypatch.setattr(frappe.db, "get_value", lambda *a, **k: "Открыта")
+    monkeypatch.setattr(frappe, "throw", lambda *a, **k: (_ for _ in ()).throw(Exception("throw")))
+    with pytest.raises(Exception):
+        service_report_hooks.validate(doc)

--- a/ferum_customs/tests/test_service_request_hooks.py
+++ b/ferum_customs/tests/test_service_request_hooks.py
@@ -1,0 +1,38 @@
+import pytest
+
+pytest.importorskip("frappe")
+import frappe
+from types import SimpleNamespace
+from ferum_customs.custom_logic import service_request_hooks
+
+
+class DummyEntry(SimpleNamespace):
+    def get(self, key):
+        return getattr(self, key, None)
+
+
+def test_get_engineers(monkeypatch):
+    doc = SimpleNamespace(
+        assigned_engineers=[
+            DummyEntry(engineer="u1"),
+            DummyEntry(engineer="u1"),
+            DummyEntry(engineer="u2"),
+        ]
+    )
+    monkeypatch.setattr(frappe, "get_doc", lambda *a, **k: doc)
+    result = service_request_hooks.get_engineers_for_object("OBJ")
+    assert set(result) == {"u1", "u2"}
+
+
+def test_get_engineers_missing(monkeypatch):
+    class DoesNotExist(Exception):
+        pass
+
+    monkeypatch.setattr(service_request_hooks.frappe, "DoesNotExistError", DoesNotExist, raising=False)
+
+    def raise_missing(*a, **k):
+        raise DoesNotExist
+
+    monkeypatch.setattr(frappe, "get_doc", raise_missing)
+    result = service_request_hooks.get_engineers_for_object("OBJ")
+    assert result == []

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,28 @@
+import shutil
+import subprocess
+import time
+
+import pytest
+import requests
+
+
+def _wait_for_site(url: str, timeout: int = 120) -> None:
+    for _ in range(timeout):
+        try:
+            requests.get(url, timeout=5)
+            return
+        except requests.RequestException:
+            time.sleep(1)
+    raise RuntimeError("Site did not start")
+
+
+@pytest.fixture(scope="session")
+def frappe_site_container():
+    if shutil.which("docker") is None:
+        pytest.skip("docker not available")
+    subprocess.check_call(["docker", "compose", "-f", "docker-compose.yml", "up", "-d", "--build"])
+    try:
+        _wait_for_site("http://localhost:8000/api/method/ping")
+        yield "http://localhost:8000"
+    finally:
+        subprocess.call(["docker", "compose", "-f", "docker-compose.yml", "down", "-v"])

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -1,0 +1,6 @@
+import requests
+
+
+def test_site_running(frappe_site_container):
+    resp = requests.get(frappe_site_container + "/api/method/ping")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add unit tests for hooks
- add integration tests that spin up Frappe container
- run tests in bench docker env in CI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c1ee14888328a6293db5164385b4