### PR TITLE
Remove redundant role creation code

### DIFF
--- a/ferum_customs/install.py
+++ b/ferum_customs/install.py
@@ -23,52 +23,8 @@ def after_install() -> None:
     Вызывается один раз после успешной установки приложения.
     """
     frappe.db.commit()  # Коммит предыдущих транзакций перед началом операций в after_install, если необходимо
-
-    # Создание кастомных ролей, если они еще не существуют.
-    # Это также можно сделать через fixtures (fixtures/role.json), что является предпочтительным способом.
-    # Логика здесь дублирует то, что может быть в role.json.
-    # Оставляем для примера, но рекомендуется использовать фикстуры.
-
-    # Список ролей для создания (должен совпадать с constants.py и fixtures/role.json)
-    custom_roles = ["Проектный менеджер", "Офис-менеджер", "Инженер", "Заказчик"]
-
-    existing_roles = {d.name for d in frappe.get_all("Role", fields=["name"])}
-
-    roles_created_count = 0
-    for role_name in custom_roles:
-        if role_name not in existing_roles:
-            try:
-                role = frappe.new_doc("Role")
-                role.role_name = role_name
-                # Можно установить другие свойства роли, если необходимо
-                # role.desk_access = 1
-                # role.is_custom = 1 # Если это кастомная роль
-                role.insert(
-                    ignore_permissions=True
-                )  # ignore_permissions может потребоваться
-                roles_created_count += 1
-                frappe.logger(__name__).info(
-                    f"Role '{role_name}' created successfully during app installation."
-                )
-            except Exception as e:
-                frappe.logger(__name__).error(
-                    f"Failed to create role '{role_name}' during app installation: {e}",
-                    exc_info=True,
-                )
-
-    if roles_created_count > 0:
-        frappe.db.commit()  # Коммит после создания ролей
-        frappe.msgprint(
-            _("{0} custom role(s) checked/created for Ferum Customs.").format(
-                roles_created_count
-            ),
-            title=_("Installation Setup"),
-            indicator="green",
-        )
-    else:
-        frappe.logger(__name__).info(
-            "All custom roles for Ferum Customs already exist."
-        )
+    # Создание ролей выполняется через фикстуры (fixtures/role.json).
+    # Дополнительная логика установки может быть добавлена при необходимости.
 
     # Пример: Добавление пользовательских полей программно (обычно делается через fixtures/custom_field.json)
     # add_custom_fields()

--- a/ferum_customs/patches/v1_0/create_custom_roles_and_permissions.py
+++ b/ferum_customs/patches/v1_0/create_custom_roles_and_permissions.py
@@ -1,9 +1,9 @@
+"""Patch placeholder for future permission migrations."""
+
 import frappe
 
 
 def execute():
-    roles = ["Проектный менеджер", "Офис-менеджер", "Инженер", "Заказчик"]
-    for role in roles:
-        if not frappe.db.exists("Role", role):
-            frappe.get_doc({"doctype": "Role", "role_name": role}).insert()
-    # Setup permissions if needed
+    """Migrate permissions if necessary."""
+    # Роли создаются через fixtures/role.json, поэтому патч пока ничего не делает
+    pass


### PR DESCRIPTION
## Summary
- drop auto-creation of roles from `after_install`
- convert role patch to placeholder

## Testing
- `pre-commit run --files ferum_customs/install.py ferum_customs/patches/v1_0/create_custom_roles_and_permissions.py` *(fails: ImportError: cannot import name 'new_site')*

------
https://chatgpt.com/codex/tasks/task_e_6841d98586ec83289d3062bd1186f428