### PR TITLE
Fix duplicate precommit step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,3 @@ jobs:
       - name: Stop bench stack
         if: always()
         run: docker compose -f docker-compose.yml down -v
-      - name: Run pre-commit
-        run: pre-commit run --all-files --show-diff-on-failure

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 black
 ruff
 pytest
-openai


### PR DESCRIPTION
## Summary
- remove redundant pre-commit step in CI workflow
- clean up `requirements.txt`

## Testing
- `pre-commit run --files .github/workflows/ci.yml requirements.txt` *(fails: ImportError: cannot import name 'new_site' from 'frappe.installer')*
- `pytest` *(fails: ImportError: cannot import name 'new_site' from 'frappe.installer')*

------
https://chatgpt.com/codex/tasks/task_e_68431030916883289fee662c2a8ea4e8