### PR TITLE
Enable customer portal for Service Request

### DIFF
--- a/ferum_customs/doctype/service_request/service_request.json
+++ b/ferum_customs/doctype/service_request/service_request.json
@@ -14,6 +14,9 @@
   "allow_rename": 1,
   "naming_series": "SR-.YYYY.-.#####",
   "title_field": "subject",
+  "has_web_view": 1,
+  "web_view_title_field": "subject",
+  "web_view_search_fields": ["subject", "status"],
   "workflow_name": "Service Request Workflow",
   "fields": [
     {

--- a/ferum_customs/fixtures/custom_docperm.json
+++ b/ferum_customs/fixtures/custom_docperm.json
@@ -61,5 +61,26 @@
     "email": 1,
     "if_owner": 0,
     "match": ""
+  },
+  {
+    "doctype": "DocPerm",
+    "name": "service_request-Customer-0",
+    "parent": "service_request",
+    "parenttype": "DocType",
+    "role": "Customer",
+    "permlevel": 0,
+    "read": 1,
+    "write": 0,
+    "create": 1,
+    "delete": 0,
+    "submit": 0,
+    "cancel": 0,
+    "amend": 0,
+    "report": 0,
+    "share": 0,
+    "print": 1,
+    "email": 1,
+    "if_owner": 0,
+    "match": ""
   }
 ]

--- a/ferum_customs/fixtures/portal_menu_item.json
+++ b/ferum_customs/fixtures/portal_menu_item.json
@@ -1,0 +1,10 @@
+[
+  {
+    "doctype": "Portal Menu Item",
+    "title": "Service Requests",
+    "route": "service-requests",
+    "reference_doctype": "service_request",
+    "role": "Customer",
+    "enabled": 1
+  }
+]

--- a/ferum_customs/hooks.py
+++ b/ferum_customs/hooks.py
@@ -31,6 +31,7 @@ fixtures = [
     "service_object",
     "service_request",
     "service_report",
+    "portal_menu_item",
     "User",
 ]
 


### PR DESCRIPTION
## Summary
- expose `service_request` to the web portal
- allow role `Customer` to create and view Service Requests

## Testing
- `pre-commit run --files ferum_customs/doctype/service_request/service_request.json ferum_customs/fixtures/custom_docperm.json ferum_customs/hooks.py ferum_customs/fixtures/portal_menu_item.json`

------
https://chatgpt.com/codex/tasks/task_e_68433a412d0c8328a843bd29fbc4a8bd