### PR TITLE
Add simple service dashboard

### DIFF
--- a/ferum_customs/dashboard_chart/engineer_workload/engineer_workload.json
+++ b/ferum_customs/dashboard_chart/engineer_workload/engineer_workload.json
@@ -1,0 +1,23 @@
+{
+ "chart_name": "Engineer Workload",
+ "chart_type": "Report",
+ "custom_options": "{}",
+ "docstatus": 0,
+ "doctype": "Dashboard Chart",
+ "dynamic_filters_json": "{}",
+ "filters_json": "{}",
+ "idx": 0,
+ "is_public": 1,
+ "is_standard": 1,
+ "module": "Ferum Customs",
+ "name": "Engineer Workload",
+ "number_of_groups": 0,
+ "owner": "Administrator",
+ "report_name": "Engineer Workload",
+ "time_interval": "Yearly",
+ "timeseries": 0,
+ "timespan": "Last Year",
+ "type": "Bar",
+ "use_report_chart": 1,
+ "y_axis": []
+}

--- a/ferum_customs/service_dashboard/service_management/service_management.json
+++ b/ferum_customs/service_dashboard/service_management/service_management.json
@@ -1,0 +1,18 @@
+{
+ "cards": [],
+ "charts": [
+  {"chart": "Engineer Workload", "width": "Full"}
+ ],
+ "creation": "2025-01-01 00:00:00.000000",
+ "dashboard_name": "Service Management",
+ "docstatus": 0,
+ "doctype": "Dashboard",
+ "idx": 0,
+ "is_default": 1,
+ "is_standard": 1,
+ "modified": "2025-01-01 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Ferum Customs",
+ "name": "Service Management",
+ "owner": "Administrator"
+}

--- a/ferum_customs/workspace/service_management/service_management.json
+++ b/ferum_customs/workspace/service_management/service_management.json
@@ -1,5 +1,7 @@
 {
- "charts": [],
+ "charts": [
+  {"chart": "Engineer Workload", "width": "Full"}
+ ],
  "content": "[]",
  "custom_blocks": [],
  "docstatus": 0,
@@ -10,7 +12,6 @@
  "idx": 0,
  "is_hidden": 0,
  "label": "Service Management",
- "links": [],
  "module": "Ferum Customs",
  "owner": "Administrator",
  "public": 1,
@@ -18,6 +19,9 @@
  "shortcuts": [
   {"label": "Service Request Overview", "link_to": "Service Request Overview", "type": "Report"},
   {"label": "Engineer Workload", "link_to": "Engineer Workload", "type": "Report"}
+],
+ "links": [
+  {"label": "Service Management Dashboard", "link_to": "Service Management", "type": "Dashboard"}
  ],
- "title": "Service Management"
+"title": "Service Management"
 }


### PR DESCRIPTION
## Summary
- create dashboard chart for Engineer Workload
- expose a dashboard with that chart
- place chart and dashboard links on the Service Management workspace

## Testing
- `pre-commit run --files ferum_customs/workspace/service_management/service_management.json ferum_customs/dashboard_chart/engineer_workload/engineer_workload.json ferum_customs/service_dashboard/service_management/service_management.json ferum_customs/service_dashboard/__init__.py` *(fails: ModuleNotFoundError: No module named 'frappe.utils')*

------
https://chatgpt.com/codex/tasks/task_e_68434c4b66f08328a8407f9115fdbb67