### PR TITLE
Update docs with Redis setup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,6 +18,16 @@
    ```
 4. **Права доступа**
    - Запускайте скрипт установки от пользователя с правами `sudo`, чтобы он мог устанавливать системные зависимости.
+5. **Установите Redis-сервер**
+   - Frappe использует Redis для фоновых задач и кеша. Установите и запустите его:
+   ```bash
+   sudo apt update && sudo apt install -y redis-server
+   redis-server --version
+   sudo systemctl status redis
+   sudo systemctl enable redis
+   sudo systemctl start redis
+   ```
+   - После старта Redis повторно запустите скрипт `./dev_bootstrap.sh`.
 
 ## Автоматическая установка
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@
 * MariaDB и Redis
 * Linux/Unix‑подобная система (рекомендуется)
 
+Перед запуском скрипта `dev_bootstrap.sh` убедитесь, что Redis установлен и запущен. Его можно установить следующей командой:
+
+```bash
+sudo apt update && sudo apt install -y redis-server
+redis-server --version
+sudo systemctl status redis
+sudo systemctl enable redis
+sudo systemctl start redis
+```
+
+После установки и запуска Redis повторно выполните `./dev_bootstrap.sh`.
+
 ## Быстрый старт
 
 ```bash


### PR DESCRIPTION
## Summary
- document Redis installation in installation guide
- add reminder in README to install and run Redis before using dev_bootstrap

## Testing
- `pre-commit run --files README.md INSTALL.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684372ac7ec88328b8f66f3099c02b8f