### PR TITLE
Refactor tests to use FrappeTestCase

### DIFF
--- a/ferum_customs/doctype/assigned_engineer_item/test_assigned_engineer_item.py
+++ b/ferum_customs/doctype/assigned_engineer_item/test_assigned_engineer_item.py
@@ -1,14 +1,13 @@
-import unittest
-
 import pytest
 
 try:
     import frappe
+    from frappe.tests.utils import FrappeTestCase
 except Exception:  # pragma: no cover
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-class TestAssignedEngineerItem(unittest.TestCase):
+class TestAssignedEngineerItem(FrappeTestCase):
     def test_assignment_date_format(self):
         doc = frappe.new_doc("Assigned Engineer Item")
         doc.engineer = " Engineer User "

--- a/ferum_customs/doctype/custom_attachment/test_custom_attachment.py
+++ b/ferum_customs/doctype/custom_attachment/test_custom_attachment.py
@@ -1,14 +1,14 @@
-import unittest
-
 import pytest
 
 try:
     import frappe
+    from frappe.tests.utils import FrappeTestCase
 except Exception:  # pragma: no cover
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-class TestCustomAttachment(unittest.TestCase):
+
+class TestCustomAttachment(FrappeTestCase):
     def test_basic(self):
         doc = frappe.new_doc("Custom Attachment")
         doc.attachment_type = " Photo "

--- a/ferum_customs/doctype/payroll_entry_custom/test_payroll_entry_custom.py
+++ b/ferum_customs/doctype/payroll_entry_custom/test_payroll_entry_custom.py
@@ -1,14 +1,13 @@
-import unittest
-
 import pytest
 
 try:
     import frappe
+    from frappe.tests.utils import FrappeTestCase
 except Exception:  # pragma: no cover
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-class TestPayrollEntryCustom(unittest.TestCase):
+class TestPayrollEntryCustom(FrappeTestCase):
     def test_total_payable_rounding(self):
         doc = frappe.new_doc("Payroll Entry Custom")
         doc.total_payable = 1234.567

--- a/ferum_customs/doctype/project_object_item/test_project_object_item.py
+++ b/ferum_customs/doctype/project_object_item/test_project_object_item.py
@@ -1,14 +1,13 @@
-import unittest
-
 import pytest
 
 try:
     import frappe
+    from frappe.tests.utils import FrappeTestCase
 except Exception:  # pragma: no cover
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-class TestProjectObjectItem(unittest.TestCase):
+class TestProjectObjectItem(FrappeTestCase):
     def test_description_trim(self):
         doc = frappe.new_doc("Project Object Item")
         doc.description = " Test description "

--- a/ferum_customs/doctype/service_object/test_service_object.py
+++ b/ferum_customs/doctype/service_object/test_service_object.py
@@ -1,14 +1,13 @@
-import unittest
-
 import pytest
 
 try:
     import frappe
+    from frappe.tests.utils import FrappeTestCase
 except Exception:  # pragma: no cover
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-class TestServiceObject(unittest.TestCase):
+class TestServiceObject(FrappeTestCase):
     def test_description_trim(self):
         doc = frappe.new_doc("Service Object")
         doc.linked_service_project = " PROJECT001 "

--- a/ferum_customs/doctype/service_project/test_service_project.py
+++ b/ferum_customs/doctype/service_project/test_service_project.py
@@ -1,14 +1,13 @@
-import unittest
-
 import pytest
 
 try:
     import frappe
+    from frappe.tests.utils import FrappeTestCase
 except Exception:  # pragma: no cover
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-class TestServiceProject(unittest.TestCase):
+class TestServiceProject(FrappeTestCase):
     def test_date_validation(self):
         doc = frappe.new_doc("Service Project")
         doc.start_date = frappe.utils.now_datetime()

--- a/ferum_customs/doctype/service_report/test_service_report.py
+++ b/ferum_customs/doctype/service_report/test_service_report.py
@@ -1,15 +1,14 @@
 import re
-import unittest
-
 import pytest
 
 try:
     import frappe
+    from frappe.tests.utils import FrappeTestCase
 except Exception:  # pragma: no cover
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-class TestServiceReport(unittest.TestCase):
+class TestServiceReport(FrappeTestCase):
     def test_basic(self):
         doc = frappe.new_doc("Service Report")
         doc.service_request = " TEST123 "

--- a/ferum_customs/tests/test_basic.py
+++ b/ferum_customs/tests/test_basic.py
@@ -1,13 +1,12 @@
-import unittest
-
 import pytest
 
 try:
     import frappe  # noqa: F401
+    from frappe.tests.utils import FrappeTestCase
 except Exception:  # pragma: no cover - frappe not installed
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-class TestTestBasic(unittest.TestCase):
+class TestTestBasic(FrappeTestCase):
     def test_basic(self):
         self.assertTrue(True)


### PR DESCRIPTION
## Summary
- base test classes now inherit from `frappe.tests.utils.FrappeTestCase`
- skip importing FrappeTestCase if `frappe` is unavailable
- drop manual setup logic from service request tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68440eeda30c8328ab49005a3d0edfb7