### PR TITLE
Refactor tests to use shared Frappe fixture

### DIFF
--- a/ferum_customs/test_api.py
+++ b/ferum_customs/test_api.py
@@ -2,14 +2,19 @@ import pytest
 
 try:
     import frappe  # noqa: F401
+    from frappe.tests.utils import FrappeTestCase
 except Exception:  # pragma: no cover
     pytest.skip("frappe not available", allow_module_level=True)
 
 from ferum_customs import api
 
 
-def test_validate_service_request():
-    """Test validate_service_request method"""
-    doc = api.validate_service_request("test_docname")
-    assert doc is not None
-    assert doc.name == "test_docname"
+pytestmark = pytest.mark.usefixtures("frappe_site")
+
+
+class TestAPI(FrappeTestCase):
+    def test_validate_service_request(self):
+        """Test validate_service_request method"""
+        doc = api.validate_service_request("test_docname")
+        self.assertIsNotNone(doc)
+        self.assertEqual(doc.name, "test_docname")

--- a/ferum_customs/tests/conftest.py
+++ b/ferum_customs/tests/conftest.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import shutil
 
@@ -20,9 +21,18 @@ def frappe_site(tmp_path_factory):
     cwd = os.getcwd()
     os.chdir(site_path)
     try:
-        new_site(
-            site_name, admin_password="admin", mariadb_root_password="root", quiet=True
-        )
+        params = inspect.signature(new_site).parameters
+        kwargs = {
+            "admin_password": "admin",
+            "db_root_password": "root",
+            "db_root_username": "root",
+            "quiet": True,
+        }
+        if "db_root_password" not in params:
+            kwargs.pop("db_root_password")
+            kwargs.pop("db_root_username")
+            kwargs["mariadb_root_password"] = "root"
+        new_site(site_name, **{k: v for k, v in kwargs.items() if k in params})
         frappe.init(site=site_name, sites_path=str(site_path))
         frappe.connect(site=site_name)
         yield site_name

--- a/ferum_customs/tests/test_create_invoice.py
+++ b/ferum_customs/tests/test_create_invoice.py
@@ -3,7 +3,11 @@ import pytest
 pytest.importorskip("frappe")
 import frappe  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
+from frappe.tests.utils import FrappeTestCase  # noqa: E402
 from ferum_customs import api  # noqa: E402
+
+
+pytestmark = pytest.mark.usefixtures("frappe_site")
 
 
 class DummyDoc(SimpleNamespace):
@@ -18,38 +22,40 @@ class DummyDoc(SimpleNamespace):
         return getattr(self, key, default)
 
 
-def test_create_invoice_success(monkeypatch):
-    sr = DummyDoc(
-        name="SR-1",
-        customer="Cust",
-        work_items=[DummyDoc(description="Work", quantity=1, unit_price=10, amount=10)],
-    )
-    invoice = DummyDoc(items=[])
+class TestCreateInvoice(FrappeTestCase):
+    def test_create_invoice_success(self, monkeypatch):
+        sr = DummyDoc(
+            name="SR-1",
+            customer="Cust",
+            work_items=[
+                DummyDoc(description="Work", quantity=1, unit_price=10, amount=10)
+            ],
+        )
+        invoice = DummyDoc(items=[])
 
-    def fake_get_doc(*args, **kwargs):
-        if isinstance(args[0], dict):
-            invoice.customer = args[0].get("customer")
-            invoice.service_report = args[0].get("service_report")
-            return invoice
-        if args[0] == "Service Report":
-            return sr
-        raise ValueError
+        def fake_get_doc(*args, **kwargs):
+            if isinstance(args[0], dict):
+                invoice.customer = args[0].get("customer")
+                invoice.service_report = args[0].get("service_report")
+                return invoice
+            if args[0] == "Service Report":
+                return sr
+            raise ValueError
 
-    monkeypatch.setattr(frappe, "get_doc", fake_get_doc)
-    monkeypatch.setattr(frappe.db, "exists", lambda *a, **k: False)
-    monkeypatch.setattr(frappe, "has_permission", lambda *a, **k: True)
+        monkeypatch.setattr(frappe, "get_doc", fake_get_doc)
+        monkeypatch.setattr(frappe.db, "exists", lambda *a, **k: False)
+        monkeypatch.setattr(frappe, "has_permission", lambda *a, **k: True)
 
-    name = api.create_invoice_from_report("SR-1")
-    assert name == "INV-1"
-    assert invoice.customer == sr.customer
-    assert invoice.service_report == "SR-1"
-    assert invoice.items[0]["qty"] == 1
+        name = api.create_invoice_from_report("SR-1")
+        self.assertEqual(name, "INV-1")
+        self.assertEqual(invoice.customer, sr.customer)
+        self.assertEqual(invoice.service_report, "SR-1")
+        self.assertEqual(invoice.items[0]["qty"], 1)
 
-
-def test_create_invoice_duplicate(monkeypatch):
-    monkeypatch.setattr(frappe.db, "exists", lambda *a, **k: True)
-    monkeypatch.setattr(
-        frappe, "throw", lambda *a, **k: (_ for _ in ()).throw(Exception("throw"))
-    )
-    with pytest.raises(Exception):
-        api.create_invoice_from_report("SR-1")
+    def test_create_invoice_duplicate(self, monkeypatch):
+        monkeypatch.setattr(frappe.db, "exists", lambda *a, **k: True)
+        monkeypatch.setattr(
+            frappe, "throw", lambda *a, **k: (_ for _ in ()).throw(Exception("throw"))
+        )
+        with pytest.raises(Exception):
+            api.create_invoice_from_report("SR-1")

--- a/ferum_customs/tests/test_service_report_hooks.py
+++ b/ferum_customs/tests/test_service_report_hooks.py
@@ -3,11 +3,14 @@ import pytest
 
 try:
     import frappe
+    from frappe.tests.utils import FrappeTestCase
 except Exception:  # pragma: no cover - frappe not installed
     pytest.skip("frappe not available", allow_module_level=True)
 
 from ferum_customs.custom_logic import service_report_hooks
 from ferum_customs.constants import STATUS_VYPOLNENA
+
+pytestmark = pytest.mark.usefixtures("frappe_site")
 
 
 class DummyDoc(SimpleNamespace):
@@ -15,28 +18,27 @@ class DummyDoc(SimpleNamespace):
         return getattr(self, key, None)
 
 
-def test_validate_ok(monkeypatch):
-    doc = DummyDoc(service_request="REQ-1", name="SR-1")
-    monkeypatch.setattr(frappe.db, "exists", lambda *a, **k: True)
-    monkeypatch.setattr(frappe.db, "get_value", lambda *a, **k: STATUS_VYPOLNENA)
-    service_report_hooks.validate(doc)
-
-
-def test_validate_missing_request(monkeypatch):
-    doc = DummyDoc(service_request=None, name="SR-1")
-    monkeypatch.setattr(
-        frappe, "throw", lambda *a, **k: (_ for _ in ()).throw(Exception("throw"))
-    )
-    with pytest.raises(Exception):
+class TestServiceReportHooks(FrappeTestCase):
+    def test_validate_ok(self, monkeypatch):
+        doc = DummyDoc(service_request="REQ-1", name="SR-1")
+        monkeypatch.setattr(frappe.db, "exists", lambda *a, **k: True)
+        monkeypatch.setattr(frappe.db, "get_value", lambda *a, **k: STATUS_VYPOLNENA)
         service_report_hooks.validate(doc)
 
+    def test_validate_missing_request(self, monkeypatch):
+        doc = DummyDoc(service_request=None, name="SR-1")
+        monkeypatch.setattr(
+            frappe, "throw", lambda *a, **k: (_ for _ in ()).throw(Exception("throw"))
+        )
+        with pytest.raises(Exception):
+            service_report_hooks.validate(doc)
 
-def test_validate_wrong_status(monkeypatch):
-    doc = DummyDoc(service_request="REQ-1", name="SR-1")
-    monkeypatch.setattr(frappe.db, "exists", lambda *a, **k: True)
-    monkeypatch.setattr(frappe.db, "get_value", lambda *a, **k: "Открыта")
-    monkeypatch.setattr(
-        frappe, "throw", lambda *a, **k: (_ for _ in ()).throw(Exception("throw"))
-    )
-    with pytest.raises(Exception):
-        service_report_hooks.validate(doc)
+    def test_validate_wrong_status(self, monkeypatch):
+        doc = DummyDoc(service_request="REQ-1", name="SR-1")
+        monkeypatch.setattr(frappe.db, "exists", lambda *a, **k: True)
+        monkeypatch.setattr(frappe.db, "get_value", lambda *a, **k: "Открыта")
+        monkeypatch.setattr(
+            frappe, "throw", lambda *a, **k: (_ for _ in ()).throw(Exception("throw"))
+        )
+        with pytest.raises(Exception):
+            service_report_hooks.validate(doc)

--- a/ferum_customs/tests/test_service_request_hooks.py
+++ b/ferum_customs/tests/test_service_request_hooks.py
@@ -3,10 +3,13 @@ import pytest
 
 try:
     import frappe
+    from frappe.tests.utils import FrappeTestCase
 except Exception:  # pragma: no cover - frappe not installed
     pytest.skip("frappe not available", allow_module_level=True)
 
 from ferum_customs.custom_logic import service_request_hooks
+
+pytestmark = pytest.mark.usefixtures("frappe_site")
 
 
 class DummyEntry(SimpleNamespace):
@@ -14,30 +17,33 @@ class DummyEntry(SimpleNamespace):
         return getattr(self, key, None)
 
 
-def test_get_engineers(monkeypatch):
-    doc = SimpleNamespace(
-        assigned_engineers=[
-            DummyEntry(engineer="u1"),
-            DummyEntry(engineer="u1"),
-            DummyEntry(engineer="u2"),
-        ]
-    )
-    monkeypatch.setattr(frappe, "get_doc", lambda *a, **k: doc)
-    result = service_request_hooks.get_engineers_for_object("OBJ")
-    assert set(result) == {"u1", "u2"}
+class TestServiceRequestHooks(FrappeTestCase):
+    def test_get_engineers(self, monkeypatch):
+        doc = SimpleNamespace(
+            assigned_engineers=[
+                DummyEntry(engineer="u1"),
+                DummyEntry(engineer="u1"),
+                DummyEntry(engineer="u2"),
+            ]
+        )
+        monkeypatch.setattr(frappe, "get_doc", lambda *a, **k: doc)
+        result = service_request_hooks.get_engineers_for_object("OBJ")
+        self.assertEqual(set(result), {"u1", "u2"})
 
+    def test_get_engineers_missing(self, monkeypatch):
+        class DoesNotExist(Exception):
+            pass
 
-def test_get_engineers_missing(monkeypatch):
-    class DoesNotExist(Exception):
-        pass
+        monkeypatch.setattr(
+            service_request_hooks.frappe,
+            "DoesNotExistError",
+            DoesNotExist,
+            raising=False,
+        )
 
-    monkeypatch.setattr(
-        service_request_hooks.frappe, "DoesNotExistError", DoesNotExist, raising=False
-    )
+        def raise_missing(*a, **k):
+            raise DoesNotExist
 
-    def raise_missing(*a, **k):
-        raise DoesNotExist
-
-    monkeypatch.setattr(frappe, "get_doc", raise_missing)
-    result = service_request_hooks.get_engineers_for_object("OBJ")
-    assert result == []
+        monkeypatch.setattr(frappe, "get_doc", raise_missing)
+        result = service_request_hooks.get_engineers_for_object("OBJ")
+        self.assertEqual(result, [])


### PR DESCRIPTION
## Summary
- centralize creation of test site with Frappe 15 API
- port tests to `FrappeTestCase` classes
- remove custom site setup logic from tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68441f3dd2f083288e3cfe5e25537582