### PR TITLE
Use shared frappe_site fixture

### DIFF
--- a/ferum_customs/doctype/assigned_engineer_item/test_assigned_engineer_item.py
+++ b/ferum_customs/doctype/assigned_engineer_item/test_assigned_engineer_item.py
@@ -7,11 +7,8 @@ except Exception:  # pragma: no cover
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-pytestmark = pytest.mark.usefixtures("frappe_site")
-
-
 class TestAssignedEngineerItem(FrappeTestCase):
-    def test_assignment_date_format(self):
+    def test_assignment_date_format(self, frappe_site):
         doc = frappe.new_doc("Assigned Engineer Item")
         doc.engineer = " Engineer User "
         doc.assignment_date = frappe.utils.now_datetime()

--- a/ferum_customs/doctype/custom_attachment/test_custom_attachment.py
+++ b/ferum_customs/doctype/custom_attachment/test_custom_attachment.py
@@ -7,11 +7,8 @@ except Exception:  # pragma: no cover
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-pytestmark = pytest.mark.usefixtures("frappe_site")
-
-
 class TestCustomAttachment(FrappeTestCase):
-    def test_basic(self):
+    def test_basic(self, frappe_site):
         doc = frappe.new_doc("Custom Attachment")
         doc.attachment_type = " Photo "
         doc.attachment_file = " /path/to/file.jpg "

--- a/ferum_customs/doctype/payroll_entry_custom/test_payroll_entry_custom.py
+++ b/ferum_customs/doctype/payroll_entry_custom/test_payroll_entry_custom.py
@@ -7,11 +7,8 @@ except Exception:  # pragma: no cover
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-pytestmark = pytest.mark.usefixtures("frappe_site")
-
-
 class TestPayrollEntryCustom(FrappeTestCase):
-    def test_total_payable_rounding(self):
+    def test_total_payable_rounding(self, frappe_site):
         doc = frappe.new_doc("Payroll Entry Custom")
         doc.total_payable = 1234.567
         doc.validate()

--- a/ferum_customs/doctype/project_object_item/test_project_object_item.py
+++ b/ferum_customs/doctype/project_object_item/test_project_object_item.py
@@ -7,11 +7,8 @@ except Exception:  # pragma: no cover
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-pytestmark = pytest.mark.usefixtures("frappe_site")
-
-
 class TestProjectObjectItem(FrappeTestCase):
-    def test_description_trim(self):
+    def test_description_trim(self, frappe_site):
         doc = frappe.new_doc("Project Object Item")
         doc.description = " Test description "
         doc.validate()

--- a/ferum_customs/doctype/service_object/test_service_object.py
+++ b/ferum_customs/doctype/service_object/test_service_object.py
@@ -7,11 +7,8 @@ except Exception:  # pragma: no cover
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-pytestmark = pytest.mark.usefixtures("frappe_site")
-
-
 class TestServiceObject(FrappeTestCase):
-    def test_description_trim(self):
+    def test_description_trim(self, frappe_site):
         doc = frappe.new_doc("Service Object")
         doc.linked_service_project = " PROJECT001 "
         doc.validate()

--- a/ferum_customs/doctype/service_project/test_service_project.py
+++ b/ferum_customs/doctype/service_project/test_service_project.py
@@ -7,11 +7,8 @@ except Exception:  # pragma: no cover
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-pytestmark = pytest.mark.usefixtures("frappe_site")
-
-
 class TestServiceProject(FrappeTestCase):
-    def test_date_validation(self):
+    def test_date_validation(self, frappe_site):
         doc = frappe.new_doc("Service Project")
         doc.start_date = frappe.utils.now_datetime()
         doc.end_date = frappe.utils.add_days(doc.start_date, -1)

--- a/ferum_customs/doctype/service_report/test_service_report.py
+++ b/ferum_customs/doctype/service_report/test_service_report.py
@@ -8,11 +8,8 @@ except Exception:  # pragma: no cover
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-pytestmark = pytest.mark.usefixtures("frappe_site")
-
-
 class TestServiceReport(FrappeTestCase):
-    def test_basic(self):
+    def test_basic(self, frappe_site):
         doc = frappe.new_doc("Service Report")
         doc.service_request = " TEST123 "
         doc.customer = " CUSTOMER1 "

--- a/ferum_customs/doctype/service_request/test_service_request.py
+++ b/ferum_customs/doctype/service_request/test_service_request.py
@@ -16,7 +16,7 @@ from ferum_customs.constants import (
     STATUS_ZAKRYTA,
 )
 
-pytestmark = pytest.mark.usefixtures("frappe_site")
+
 
 # Constants used in tests. FrappeTestCase will provide matching fixtures.
 TEST_CUSTOMER_NAME = "_Test Customer for SR Tests"
@@ -71,7 +71,7 @@ class TestServiceRequest(FrappeTestCase):
                     raise
         return sr
 
-    def test_sr_creation_and_custom_fields(self):
+    def test_sr_creation_and_custom_fields(self, frappe_site):
         sr = self.create_service_request_doc()
         self.assertEqual(sr.custom_customer, self.test_customer_name)
         self.assertEqual(sr.custom_service_object_link, self.actual_test_so_name)
@@ -80,7 +80,7 @@ class TestServiceRequest(FrappeTestCase):
         fetched_sr = frappe.get_doc("service_request", sr.name)
         self.assertEqual(fetched_sr.custom_project, self.actual_test_sp_name)
 
-    def test_validate_vyapolnena_requires_linked_report(self):
+    def test_validate_vyapolnena_requires_linked_report(self, frappe_site):
         sr = self.create_service_request_doc(status=STATUS_OTKRYTA, submit_doc=True)
         sr.status = STATUS_VYPOLNENA  # Имитируем изменение статуса
         # sr.custom_linked_report = None # Убедимся, что поле пустое (оно и так будет None для нового SR)
@@ -91,7 +91,7 @@ class TestServiceRequest(FrappeTestCase):
         ):
             sr.save()  # save вызовет validate
 
-    def test_hook_get_engineers_for_object(self):
+    def test_hook_get_engineers_for_object(self, frappe_site):
         from ferum_customs.custom_logic.service_request_hooks import (
             get_engineers_for_object,
         )
@@ -99,7 +99,7 @@ class TestServiceRequest(FrappeTestCase):
         engineers = get_engineers_for_object(self.actual_test_so_name)
         self.assertIn(self.test_engineer_user_email, engineers)
 
-    def test_sr_controller_internal_methods_with_custom_fields(self):
+    def test_sr_controller_internal_methods_with_custom_fields(self, frappe_site):
         sr_doc = frappe.new_doc("service_request")
         sr_doc.subject = " Test Subject for Cleaning "
         # Даты
@@ -129,7 +129,7 @@ class TestServiceRequest(FrappeTestCase):
         self.assertAlmostEqual(sr_doc.duration_hours, 12.0, places=2)
 
     @patch("frappe.sendmail")  # Мокируем функцию frappe.sendmail
-    def test_notify_project_manager_on_close(self, mock_sendmail_func):
+    def test_notify_project_manager_on_close(self, mock_sendmail_func, frappe_site):
         sr = self.create_service_request_doc(status=STATUS_OTKRYTA, submit_doc=True)
 
         # Имитируем изменение статуса на Закрыта

--- a/ferum_customs/test_api.py
+++ b/ferum_customs/test_api.py
@@ -9,11 +9,8 @@ except Exception:  # pragma: no cover
 from ferum_customs import api
 
 
-pytestmark = pytest.mark.usefixtures("frappe_site")
-
-
 class TestAPI(FrappeTestCase):
-    def test_validate_service_request(self):
+    def test_validate_service_request(self, frappe_site):
         """Test validate_service_request method"""
         doc = api.validate_service_request("test_docname")
         self.assertIsNotNone(doc)

--- a/ferum_customs/tests/test_basic.py
+++ b/ferum_customs/tests/test_basic.py
@@ -7,9 +7,7 @@ except Exception:  # pragma: no cover - frappe not installed
     pytest.skip("frappe not available", allow_module_level=True)
 
 
-pytestmark = pytest.mark.usefixtures("frappe_site")
-
 
 class TestTestBasic(FrappeTestCase):
-    def test_basic(self):
+    def test_basic(self, frappe_site):
         self.assertTrue(True)

--- a/ferum_customs/tests/test_create_invoice.py
+++ b/ferum_customs/tests/test_create_invoice.py
@@ -7,9 +7,6 @@ from frappe.tests.utils import FrappeTestCase  # noqa: E402
 from ferum_customs import api  # noqa: E402
 
 
-pytestmark = pytest.mark.usefixtures("frappe_site")
-
-
 class DummyDoc(SimpleNamespace):
     def append(self, field, value):
         getattr(self, field).append(value)
@@ -23,7 +20,7 @@ class DummyDoc(SimpleNamespace):
 
 
 class TestCreateInvoice(FrappeTestCase):
-    def test_create_invoice_success(self, monkeypatch):
+    def test_create_invoice_success(self, monkeypatch, frappe_site):
         sr = DummyDoc(
             name="SR-1",
             customer="Cust",
@@ -52,7 +49,7 @@ class TestCreateInvoice(FrappeTestCase):
         self.assertEqual(invoice.service_report, "SR-1")
         self.assertEqual(invoice.items[0]["qty"], 1)
 
-    def test_create_invoice_duplicate(self, monkeypatch):
+    def test_create_invoice_duplicate(self, monkeypatch, frappe_site):
         monkeypatch.setattr(frappe.db, "exists", lambda *a, **k: True)
         monkeypatch.setattr(
             frappe, "throw", lambda *a, **k: (_ for _ in ()).throw(Exception("throw"))

--- a/ferum_customs/tests/test_service_object_hooks.py
+++ b/ferum_customs/tests/test_service_object_hooks.py
@@ -8,9 +8,6 @@ except Exception:  # pragma: no cover - frappe not installed
 
 from ferum_customs.custom_logic import service_object_hooks
 
-pytestmark = pytest.mark.usefixtures("frappe_site")
-
-
 class DummyDoc:
     def __init__(self, serial_no, name="SO-0001"):
         self.serial_no = serial_no
@@ -21,7 +18,7 @@ class DummyDoc:
 
 
 class TestServiceObjectHooks(FrappeTestCase):
-    def test_validate_unique(self, monkeypatch):
+    def test_validate_unique(self, monkeypatch, frappe_site):
         doc = DummyDoc("SN-1")
         monkeypatch.setattr(frappe.db, "exists", lambda *args, **kwargs: None)
         monkeypatch.setattr(
@@ -30,7 +27,7 @@ class TestServiceObjectHooks(FrappeTestCase):
         # Should not raise
         service_object_hooks.validate(doc)
 
-    def test_validate_duplicate(self, monkeypatch):
+    def test_validate_duplicate(self, monkeypatch, frappe_site):
         doc = DummyDoc("SN-1")
         monkeypatch.setattr(frappe.db, "exists", lambda *a, **k: "SO-0002")
 

--- a/ferum_customs/tests/test_service_report_hooks.py
+++ b/ferum_customs/tests/test_service_report_hooks.py
@@ -10,22 +10,19 @@ except Exception:  # pragma: no cover - frappe not installed
 from ferum_customs.custom_logic import service_report_hooks
 from ferum_customs.constants import STATUS_VYPOLNENA
 
-pytestmark = pytest.mark.usefixtures("frappe_site")
-
-
 class DummyDoc(SimpleNamespace):
     def get(self, key):
         return getattr(self, key, None)
 
 
 class TestServiceReportHooks(FrappeTestCase):
-    def test_validate_ok(self, monkeypatch):
+    def test_validate_ok(self, monkeypatch, frappe_site):
         doc = DummyDoc(service_request="REQ-1", name="SR-1")
         monkeypatch.setattr(frappe.db, "exists", lambda *a, **k: True)
         monkeypatch.setattr(frappe.db, "get_value", lambda *a, **k: STATUS_VYPOLNENA)
         service_report_hooks.validate(doc)
 
-    def test_validate_missing_request(self, monkeypatch):
+    def test_validate_missing_request(self, monkeypatch, frappe_site):
         doc = DummyDoc(service_request=None, name="SR-1")
         monkeypatch.setattr(
             frappe, "throw", lambda *a, **k: (_ for _ in ()).throw(Exception("throw"))
@@ -33,7 +30,7 @@ class TestServiceReportHooks(FrappeTestCase):
         with pytest.raises(Exception):
             service_report_hooks.validate(doc)
 
-    def test_validate_wrong_status(self, monkeypatch):
+    def test_validate_wrong_status(self, monkeypatch, frappe_site):
         doc = DummyDoc(service_request="REQ-1", name="SR-1")
         monkeypatch.setattr(frappe.db, "exists", lambda *a, **k: True)
         monkeypatch.setattr(frappe.db, "get_value", lambda *a, **k: "Открыта")

--- a/ferum_customs/tests/test_service_request_hooks.py
+++ b/ferum_customs/tests/test_service_request_hooks.py
@@ -9,16 +9,13 @@ except Exception:  # pragma: no cover - frappe not installed
 
 from ferum_customs.custom_logic import service_request_hooks
 
-pytestmark = pytest.mark.usefixtures("frappe_site")
-
-
 class DummyEntry(SimpleNamespace):
     def get(self, key):
         return getattr(self, key, None)
 
 
 class TestServiceRequestHooks(FrappeTestCase):
-    def test_get_engineers(self, monkeypatch):
+    def test_get_engineers(self, monkeypatch, frappe_site):
         doc = SimpleNamespace(
             assigned_engineers=[
                 DummyEntry(engineer="u1"),
@@ -30,7 +27,7 @@ class TestServiceRequestHooks(FrappeTestCase):
         result = service_request_hooks.get_engineers_for_object("OBJ")
         self.assertEqual(set(result), {"u1", "u2"})
 
-    def test_get_engineers_missing(self, monkeypatch):
+    def test_get_engineers_missing(self, monkeypatch, frappe_site):
         class DoesNotExist(Exception):
             pass
 

--- a/ferum_customs/tests/test_utils.py
+++ b/ferum_customs/tests/test_utils.py
@@ -7,16 +7,13 @@ from frappe.tests.utils import FrappeTestCase  # noqa: E402
 from ferum_customs.custom_logic import service_request_hooks  # noqa: E402
 
 
-pytestmark = pytest.mark.usefixtures("frappe_site")
-
-
 class DummyEntry(SimpleNamespace):
     def get(self, key):
         return getattr(self, key, None)
 
 
 class TestUtils(FrappeTestCase):
-    def test_get_engineers_for_object(self, monkeypatch):
+    def test_get_engineers_for_object(self, monkeypatch, frappe_site):
         doc = SimpleNamespace(
             assigned_engineers=[
                 DummyEntry(engineer="u1"),
@@ -28,7 +25,7 @@ class TestUtils(FrappeTestCase):
         result = service_request_hooks.get_engineers_for_object("OBJ")
         self.assertEqual(set(result), {"u1", "u2"})
 
-    def test_get_engineers_missing(self, monkeypatch):
+    def test_get_engineers_missing(self, monkeypatch, frappe_site):
         class DoesNotExist(Exception):
             pass
 


### PR DESCRIPTION
## Summary
- ensure a single test site is created in `tests/conftest.py`
- use the new fixture in doctypes and API tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684423ec115483289f0c3610252976ef