### PR TITLE
Fix install-dev script

### DIFF
--- a/install-dev.sh
+++ b/install-dev.sh
@@ -8,4 +8,4 @@ fi
 
 source .venv/bin/activate
 pip install -U pip
-pip install -r requirements.txt
+pip install -r dev-requirements.txt


### PR DESCRIPTION
## Summary
- use dev requirements file in install script

## Testing
- `pre-commit run --files install-dev.sh` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_684455d57aec8328bd6768b41bb70cb1