### PR TITLE
Fix bench invocation and CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         run: |
           pip install -r dev-requirements.txt
           pip install pre-commit
+          pip install frappe-bench
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Start bench stack
         run: docker compose -f docker-compose.yml up -d --build
       - name: Run pre-commit


### PR DESCRIPTION
## Summary
- replace bench CLI calls in tests with direct module execution
- skip tests if `frappe` is missing
- update CI to install `frappe-bench`

## Testing
- `pre-commit run --files .github/workflows/ci.yml ferum_customs/tests/conftest.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684459e4d904832891fb812c40ed5b18