### PR TITLE
Fix Node.js installation in setup script

### DIFF
--- a/setup-environment.sh
+++ b/setup-environment.sh
@@ -10,7 +10,14 @@ APP_PATH="$(cd "$(dirname "$0")" && pwd)"
 # Update packages and install system dependencies
 sudo apt-get update
 sudo apt-get install -y git python3 python3-venv python3-dev \
-    mariadb-server redis-server nodejs npm yarn curl build-essential
+    mariadb-server redis-server curl build-essential
+
+# Install Node.js 18 from NodeSource (includes npm)
+curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+# Install Yarn globally using npm to avoid package conflicts
+sudo npm install -g yarn
 
 # Install bench CLI if not present
 if ! command -v bench >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- install Node.js 18 from NodeSource in `setup-environment.sh`
- install Yarn via npm to avoid package conflicts

## Testing
- `pre-commit run --files setup-environment.sh` *(fails: pre-commit not found)*
- `pip install -r dev-requirements.txt` *(incomplete due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68445eec868c8328b5a98b69f11e7eb8